### PR TITLE
Title1 component

### DIFF
--- a/app/src/main/java/ar/edu/ort/tp3_ort_2025_parcial/component/title/title1.kt
+++ b/app/src/main/java/ar/edu/ort/tp3_ort_2025_parcial/component/title/title1.kt
@@ -1,0 +1,25 @@
+package ar.edu.ort.tp3_ort_2025_parcial.component.title
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import ar.edu.ort.tp3_ort_2025_parcial.ui.theme.Black
+
+@Preview
+@Composable
+fun Title1Preview(){
+    Title1(
+        text = "Test"
+    )
+}
+
+@Composable
+fun Title1(
+    text: String
+){
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleLarge.copy(color = Black)
+    )
+}


### PR DESCRIPTION
This commit introduces a reusable `Title1` Composable function for displaying a large title with a black color.

- A `Title1` Composable function is created that takes a `text` string as input.
- It uses `MaterialTheme.typography.titleLarge` with `color = Black`.
- A `@Preview` function `Title1Preview` is added to demonstrate its usage.